### PR TITLE
Fix Typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Use **getContestTypeByName** to return data about the effects of moves when used
 Use **getContestEffectById** to return data about the effects of moves when used in contests.
 
 ```js
-  P.getContestTypeByName(1)
+  P.getContestEffectById(1)
     .then(function(response) {
       console.log(response);
     });
@@ -174,7 +174,7 @@ Use **getContestEffectById** to return data about the effects of moves when used
 Use **getSuperContestEffectById** to return data about the effects of moves when used in super contests.
 
 ```js
-  P.getSuperContestTypeById(1)
+  P.getSuperContestEffectById(1)
     .then(function(response) {
       console.log(response);
     });


### PR DESCRIPTION
Fixed examples for getContestEffectById and getSuperContestEffectById in readme.md