### PR TITLE
fix Array check statement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ export class Pokedex {
     resource(path) {
         if (typeof path === 'string') {
             return loadResource(this.config, path)
-        } else if (typeof path === 'object') {
+        } else if (Array.isArray(path)) {
             return Promise.all(path.map(p => loadResource(this.config, p)))
         } else {
             return 'String or Array is required'


### PR DESCRIPTION
In the current version, if you pass any type of an object/non-primitive data, like a JavaScript object:
 ` } else if (typeof {key1: 1, key2:2 } === 'object') {`
 this else-if-statement would trigger, and would try to pass in the object into `return Promise.all()`, which can only take in an array.

This Pull request changes the check if an item is an object, to something more specific to what the `Promise.all()` method can accept, which is an array. The suggested change is from:
```js
 } else if (typeof path === 'object') {
 ```
 to:
 ```js
 } else if (Array.isArray(path)) {
 ```