### PR TITLE
Added a retry fetch without "/" if the origin is failed.

### DIFF
--- a/src/getter.js
+++ b/src/getter.js
@@ -28,10 +28,10 @@ function loadResource(config, url) {
     })
 }
 
-function loadUrl(config, url) {
+function loadUrl(config, url, isRetry=false) {
     return new Promise((resolve, reject) => {
         let options = {
-            baseURL: `${config.protocol}://${config.hostName}/`,
+            baseURL: `${config.protocol}://${config.hostName}` + (isRetry ? '' : '/'),
             timeout: config.timeout
         }
         axios.get(url, options)
@@ -49,7 +49,15 @@ function loadUrl(config, url) {
                     resolve(response.data)
                 }  
             })
-            .catch(err => { reject(err) }) 
+            .catch(err => {
+                if (!isRetry){
+                    return loadUrl(config, url, isRetry=true)
+                    .then(res => {resolve(res)})
+                    .catch(err => {reject(err)})
+                } else {
+                    reject(err)
+                }
+            }) 
     })
 }
 


### PR DESCRIPTION
People will encounter errors when "/" present at the end of url. According to pokeapi it is something related to Cloudflare. 
Added a retry to workaround it. 